### PR TITLE
Add new Copenhagen store

### DIFF
--- a/packages/static/src/all-stores.ts
+++ b/packages/static/src/all-stores.ts
@@ -2514,6 +2514,13 @@ export const ALL_STORES: Store[] = [
     longitude: 139.7032,
   },
   {
+    id: "686",
+    name: "IKEA København",
+    country: "dk",
+    latitude: 55.663885,
+    longitude: 12.561302
+  },
+  {
     id: "802",
     name: "IKEA Siyuanqiao",
     country: "cn",


### PR DESCRIPTION
This adds the new Ikea store in Copenhagen with the store ID from the Ikea API (checked via the item availability and the only store ID that wasn't in this list was 686) and the coordinates of the store from GMaps.