### PR TITLE
Remove IKEA Tottenham

### DIFF
--- a/packages/static/src/all-stores.ts
+++ b/packages/static/src/all-stores.ts
@@ -778,13 +778,6 @@ export const ALL_STORES: Store[] = [
     longitude: -97.2104,
   },
   {
-    id: "255",
-    name: "IKEA Tottenham",
-    country: "gb",
-    latitude: 51.6093,
-    longitude: -0.0486,
-  },
-  {
     id: "256",
     name: "IKEA Etobicoke",
     country: "ca",


### PR DESCRIPTION
IKEA Tottenham has been closed. See #3 